### PR TITLE
Return Environment in Response

### DIFF
--- a/lib/dolla/response.ex
+++ b/lib/dolla/response.ex
@@ -3,7 +3,7 @@ defmodule Dolla.Response do
   alias Dolla.Receipt
   alias Dolla.InAppReceipt
 
-  defstruct [:status, :receipt, :latest_receipt, :latest_receipt_info, :error]
+  defstruct [:status, :environment, :receipt, :latest_receipt, :latest_receipt_info, :error]
 
   defmodule ValidationError do
     defexception [:status, :message]


### PR DESCRIPTION
Currently the response does not specify if the environment is Sandbox or Production.

This PR fixes that.